### PR TITLE
Fix typo in INSTANCE value in build-docs workflow file

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  INSTANCE: 'WAF-toAthena/in'
+  INSTANCE: 'WAF-to-Athena/in'
   DOCKER_VERSION: '243.22562'
 
 jobs:


### PR DESCRIPTION
Corrected a naming inconsistency in the INSTANCE variable from 'WAF-toAthena/in' to 'WAF-to-Athena/in'. This ensures clarity and alignment with expected naming conventions.

## Summary by Sourcery

Bug Fixes:
- Fix a typo in the INSTANCE environment variable in the build-docs workflow file, correcting it from 'WAF-toAthena/in' to 'WAF-to-Athena/in'.