### PR TITLE
Add new module and duplicate instance reference in config

### DIFF
--- a/Writerside/writerside.cfg
+++ b/Writerside/writerside.cfg
@@ -8,4 +8,6 @@
     <categories src="c.list"/>
     <vars src="v.list"/>
     <instance src="in.tree"/>
+    <module name="WAF-to-Athena" />
+    <instance src="in.tree" />
 </ihp>


### PR DESCRIPTION
Added the "WAF-to-Athena" module and duplicated the instance "in.tree" reference in the writerside.cfg file. This update reflects necessary configuration adjustments for module integration.

## Summary by Sourcery

Adds the "WAF-to-Athena" module to the configuration and duplicates the instance "in.tree" reference.

Chores:
- Adds the "WAF-to-Athena" module to the configuration.
- Duplicates the instance "in.tree" reference in the configuration.